### PR TITLE
Fix rematch issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,13 +3,11 @@ from flask_socketio import SocketIO, emit, join_room, leave_room
 import secrets
 import os
 import random
-import time
 from datetime import datetime, UTC, timedelta
 from threading import Timer
 import logging
 from models import db, Player, Match
 from config import Config
-import threading
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
@@ -24,18 +22,35 @@ db.init_app(app)
 # Create tables
 with app.app_context():
     db.create_all()
+    # Clean up any stale matches
+    try:
+        stale_matches = Match.query.filter(Match.status.in_(['playing', 'waiting'])).all()
+        for match in stale_matches:
+            if match.creator_id:
+                creator = Player.query.filter_by(session_id=match.creator_id).first()
+                if creator:
+                    creator.current_match_id = None
+            if match.joiner_id:
+                joiner = Player.query.filter_by(session_id=match.joiner_id).first()
+                if joiner:
+                    joiner.current_match_id = None
+            db.session.delete(match)
+        db.session.commit()
+    except Exception as e:
+        logger.exception("Error cleaning up stale matches")
+        db.session.rollback()
 
 # Configure Flask-SocketIO
 socketio = SocketIO(
     app,
-    async_mode='gevent',  # Use gevent for WebSocket support
-    cors_allowed_origins='*',  # Allow all origins in development
+    async_mode='gevent',
+    cors_allowed_origins='*',
     logger=True,
     engineio_logger=True,
     ping_timeout=60,
     ping_interval=25,
     max_http_buffer_size=1000000,
-    manage_session=False  # Let Flask manage the sessions
+    manage_session=False
 )
 
 # Match timers storage
@@ -47,99 +62,6 @@ def get_match(match_id):
 
 def random_move():
     return random.choice(['rock', 'paper', 'scissors'])
-
-def cleanup_stale_matches():
-    """Clean up matches that have been stuck in 'playing' or 'waiting' state for too long."""
-    try:
-        with app.app_context():
-            # Find matches that have been in 'playing' state for more than 30 seconds
-            cutoff_time = datetime.now(UTC) - timedelta(seconds=30)
-            stale_matches = Match.query.filter(
-                Match.status.in_(['playing', 'waiting'])
-            ).all()
-            
-            # Filter matches manually to handle naive datetimes
-            stale_matches = [
-                match for match in stale_matches
-                if match.started_at and (
-                    match.started_at.replace(tzinfo=UTC) if match.started_at.tzinfo is None
-                    else match.started_at
-                ) < cutoff_time
-            ]
-            
-            for match in stale_matches:
-                logger.info(f"Cleaning up stale match {match.id}")
-                if match.status == 'playing':
-                    handle_match_timeout(match.id)
-                else:
-                    # For waiting matches, just clean up and reset player states
-                    try:
-                        if match.creator_id:
-                            creator = Player.query.filter_by(session_id=match.creator_id).first()
-                            if creator and creator.current_match_id == match.id:
-                                creator.current_match_id = None
-                        if match.joiner_id:
-                            joiner = Player.query.filter_by(session_id=match.joiner_id).first()
-                            if joiner and joiner.current_match_id == match.id:
-                                joiner.current_match_id = None
-                        db.session.delete(match)
-                        db.session.commit()
-                        logger.info(f"Cleaned up waiting match {match.id}")
-                    except Exception as e:
-                        logger.exception(f"Error cleaning up waiting match {match.id}")
-                        db.session.rollback()
-    except Exception as e:
-        logger.exception("Error cleaning up stale matches")
-
-def handle_match_timeout(match_id):
-    try:
-        match = get_match(match_id)
-        if not match:
-            logger.error(f"Match {match_id} not found in timeout handler")
-            return
-        
-        if match.status != 'playing':
-            logger.error(f"Match {match_id} not in playing state in timeout handler")
-            return
-        
-        logger.info(f"Match {match_id} timed out. Processing...")
-        
-        # Assign random moves to players who haven't made a move
-        if not match.creator_move:
-            move = random_move()
-            match.creator_move = move
-            logger.info(f"Assigned random move {move} to creator in match {match_id}")
-            socketio.emit('move_made', {'player': 'creator', 'auto': True}, room=match_id)
-        
-        if not match.joiner_move:
-            move = random_move()
-            match.joiner_move = move
-            logger.info(f"Assigned random move {move} to joiner in match {match_id}")
-            socketio.emit('move_made', {'player': 'joiner', 'auto': True}, room=match_id)
-        
-        db.session.commit()
-        
-        # Calculate and emit result
-        calculate_and_emit_result(match_id)
-    except Exception as e:
-        logger.exception(f"Error in match timeout handler for match {match_id}")
-        # Try to clean up the match in case of error
-        try:
-            match = get_match(match_id)
-            if match:
-                match.status = 'finished'
-                match.finished_at = datetime.now(UTC)
-                if match.creator_id:
-                    creator = Player.query.filter_by(session_id=match.creator_id).first()
-                    if creator:
-                        creator.current_match_id = None
-                if match.joiner_id:
-                    joiner = Player.query.filter_by(session_id=match.joiner_id).first()
-                    if joiner:
-                        joiner.current_match_id = None
-                db.session.commit()
-        except Exception as cleanup_error:
-            logger.exception(f"Error cleaning up match {match_id} after timeout error")
 
 def calculate_winner(move1, move2):
     if move1 == move2:
@@ -171,7 +93,6 @@ def get_state():
     try:
         session_id = session.get('session_id')
         if not session_id:
-            # Create new session if none exists
             session_id = generate_session_id()
             session['session_id'] = session_id
             new_player = Player(session_id=session_id)
@@ -181,21 +102,15 @@ def get_state():
         
         player = Player.query.filter_by(session_id=session_id).first()
         if not player:
-            # Reinitialize player if not found
             player = Player(session_id=session_id)
             db.session.add(player)
             db.session.commit()
             logger.info(f"Reinitialized player: {session_id}")
         
-        # Update last active timestamp
         player.last_active = datetime.now(UTC)
         db.session.commit()
         
-        # Get open matches that:
-        # 1. Are in waiting state
-        # 2. Are not created by current player
-        # 3. Have a creator with enough coins
-        # 4. Current player has enough coins to join
+        # Get open matches
         open_matches = []
         available_matches = Match.query.filter_by(status='waiting').all()
         
@@ -208,31 +123,20 @@ def get_state():
                     'stake': match.stake
                 })
         
-        # Get current match details if in a match
+        # Get current match details
         current_match = None
         if player.current_match_id:
             match = get_match(player.current_match_id)
             if match:
-                # Check if match is stale
-                if match.started_at:
-                    cutoff_time = datetime.now(UTC) - timedelta(seconds=30)
-                    match_time = match.started_at.replace(tzinfo=UTC) if match.started_at.tzinfo is None else match.started_at
-                    if match_time < cutoff_time and match.status == 'playing':
-                        # Clean up stale match
-                        handle_match_timeout(match.id)
-                        match = None
-                
-                if match:
-                    current_match = {
-                        'id': match.id,
-                        'status': match.status,
-                        'stake': match.stake,
-                        'is_creator': session_id == match.creator_id,
-                        'creator_ready': match.creator_ready,
-                        'joiner_ready': match.joiner_ready
-                    }
+                current_match = {
+                    'id': match.id,
+                    'status': match.status,
+                    'stake': match.stake,
+                    'is_creator': session_id == match.creator_id,
+                    'creator_ready': match.creator_ready,
+                    'joiner_ready': match.joiner_ready
+                }
         
-        logger.debug(f"State for {session_id}: coins={player.coins}, current_match={current_match}")
         return jsonify({
             'coins': player.coins,
             'stats': {
@@ -255,24 +159,20 @@ def create_match():
         session_id = session.get('session_id')
         player = Player.query.filter_by(session_id=session_id).first()
         if not player:
-            logger.error(f"Invalid session: {session_id}")
             return jsonify({'error': 'Invalid session'}), 400
         
         stake = request.json.get('stake', 0)
         if not isinstance(stake, int) or stake <= 0:
-            logger.error(f"Invalid stake: {stake}")
             return jsonify({'error': 'Invalid stake'}), 400
         
         if player.coins < stake:
-            logger.error(f"Insufficient coins. Has: {player.coins}, Needs: {stake}")
             return jsonify({'error': 'Insufficient coins'}), 400
         
         # Clear any existing match
         if player.current_match_id:
             current_match = get_match(player.current_match_id)
             if current_match:
-                logger.info(f"Cleaning up existing match: {current_match.id}")
-                if current_match.id in match_timers and match_timers[current_match.id]:
+                if current_match.id in match_timers:
                     match_timers[current_match.id].cancel()
                     match_timers.pop(current_match.id)
                 db.session.delete(current_match)
@@ -284,15 +184,13 @@ def create_match():
             creator_id=session_id,
             stake=stake,
             status='waiting',
-            creator_ready=True  # Creator is automatically ready
+            creator_ready=True
         )
         
         db.session.add(new_match)
         player.current_match_id = match_id
         db.session.commit()
         
-        logger.info(f"Match created: {match_id} by {session_id}")
-        logger.info(f"Creator {session_id} ready in match {match_id}")
         return jsonify({'match_id': match_id})
     except Exception as e:
         logger.exception("Error creating match")
@@ -304,40 +202,33 @@ def join_match():
         session_id = session.get('session_id')
         player = Player.query.filter_by(session_id=session_id).first()
         if not player:
-            logger.error(f"Invalid session: {session_id}")
             return jsonify({'error': 'Invalid session'}), 400
         
         match_id = request.json.get('match_id')
         match = get_match(match_id)
         if not match:
-            logger.error(f"Invalid match: {match_id}")
             return jsonify({'error': 'Invalid match'}), 400
         
         if match.status != 'waiting':
-            logger.error(f"Match not available. Status: {match.status}")
             return jsonify({'error': 'Match not available'}), 400
         
         if player.coins < match.stake:
-            logger.error(f"Insufficient coins. Has: {player.coins}, Needs: {match.stake}")
             return jsonify({'error': 'Insufficient coins'}), 400
         
-        # Clear any existing match for the joining player
+        # Clear any existing match
         if player.current_match_id and player.current_match_id != match_id:
             current_match = get_match(player.current_match_id)
             if current_match:
-                logger.info(f"Cleaning up existing match: {current_match.id}")
-                if current_match.id in match_timers and match_timers[current_match.id]:
+                if current_match.id in match_timers:
                     match_timers[current_match.id].cancel()
                     match_timers.pop(current_match.id)
                 db.session.delete(current_match)
             player.current_match_id = None
         
-        # Update match and player state
         match.joiner_id = session_id
         player.current_match_id = match_id
         db.session.commit()
         
-        logger.info(f"Player {session_id} joined match {match_id}")
         return jsonify({'success': True})
     except Exception as e:
         logger.exception("Error joining match")
@@ -349,71 +240,38 @@ def make_move():
         session_id = session.get('session_id')
         player = Player.query.filter_by(session_id=session_id).first()
         if not player:
-            logger.error(f"Invalid session: {session_id}")
             return jsonify({'error': 'Invalid session'}), 400
         
         move = request.json.get('move')
         if move not in ['rock', 'paper', 'scissors']:
-            logger.error(f"Invalid move: {move}")
             return jsonify({'error': 'Invalid move'}), 400
         
-        # Lock the player for update to get the latest state
-        player = Player.query.filter_by(session_id=session_id).with_for_update().first()
-        if not player:
-            logger.error(f"Player {session_id} disappeared")
-            return jsonify({'error': 'Player not found'}), 400
-        
         if not player.current_match_id:
-            logger.error(f"No active match for player {session_id}")
             return jsonify({'error': 'No active match'}), 400
         
-        # Lock the match for update
         match = Match.query.filter_by(id=player.current_match_id).with_for_update().first()
         if not match:
-            logger.error(f"Match {player.current_match_id} not found")
             return jsonify({'error': 'Match not found'}), 400
         
-        # Check if match is too old (more than 10 seconds)
-        if match.started_at:
-            # Convert naive datetime to UTC
-            if match.started_at.tzinfo is None:
-                match_start = match.started_at.replace(tzinfo=UTC)
-            else:
-                match_start = match.started_at
-            
-            if match_start < datetime.now(UTC) - timedelta(seconds=10):
-                logger.error(f"Match {match.id} has timed out")
-                handle_match_timeout(match.id)
-                return jsonify({'error': 'Match has timed out. Random moves were assigned.'}), 400
-        
         if match.status != 'playing':
-            logger.error(f"Match {match.id} not in playing state. Status: {match.status}")
             return jsonify({'error': 'Match not in playing state'}), 400
         
-        # Check if player is part of the match
         if session_id not in [match.creator_id, match.joiner_id]:
-            logger.error(f"Player {session_id} not part of match {match.id}")
             return jsonify({'error': 'Not part of match'}), 400
         
-        # Check if player already made a move
         if (session_id == match.creator_id and match.creator_move) or \
            (session_id == match.joiner_id and match.joiner_move):
-            logger.error(f"Player {session_id} already made a move in match {match.id}")
             return jsonify({'error': 'Already made a move'}), 400
         
-        # Record the move
         if session_id == match.creator_id:
             match.creator_move = move
-            logger.info(f"Creator {session_id} made move {move} in match {match.id}")
-            socketio.emit('move_made', {'player': 'creator'}, room=match_id)
+            socketio.emit('move_made', {'player': 'creator'}, room=match.id)
         else:
             match.joiner_move = move
-            logger.info(f"Joiner {session_id} made move {move} in match {match.id}")
-            socketio.emit('move_made', {'player': 'joiner'}, room=match_id)
+            socketio.emit('move_made', {'player': 'joiner'}, room=match.id)
         
         db.session.commit()
         
-        # If both players have moved, calculate and emit result
         if match.creator_move and match.joiner_move:
             calculate_and_emit_result(match.id)
         
@@ -425,52 +283,40 @@ def make_move():
 def calculate_and_emit_result(match_id):
     try:
         match = get_match(match_id)
-        if not match:
-            logger.error(f"Match {match_id} not found in result calculation")
+        if not match or not match.creator_move or not match.joiner_move:
             return
         
-        if not match.creator_move or not match.joiner_move:
-            logger.error(f"Missing moves in match {match_id}")
-            return
-        
-        # Calculate winner
         result = calculate_winner(match.creator_move, match.joiner_move)
         
-        # Get players
         creator = Player.query.filter_by(session_id=match.creator_id).first()
         joiner = Player.query.filter_by(session_id=match.joiner_id).first()
         
         if not creator or not joiner:
-            logger.error(f"Players not found for match {match_id}")
             return
         
-        # Store stake for potential rematch
         stake = match.stake
         
-        # Update match state
         match.status = 'finished'
         match.finished_at = datetime.now(UTC)
-        match.creator_ready = False  # Reset ready states for rematch
+        match.creator_ready = False
         match.joiner_ready = False
         
-        # Keep match references for rematch
         creator.current_match_id = match.id
         joiner.current_match_id = match.id
         
-        # Update player stats and coins
         if result == 'draw':
             creator.draws += 1
             joiner.draws += 1
             creator.coins += stake
             joiner.coins += stake
-        elif result == 'player1':  # Creator wins
+        elif result == 'player1':
             creator.wins += 1
             joiner.losses += 1
             creator.coins += stake * 2
             creator.total_coins_won += stake
             joiner.total_coins_lost += stake
             match.winner_id = creator.session_id
-        else:  # Joiner wins
+        else:
             creator.losses += 1
             joiner.wins += 1
             joiner.coins += stake * 2
@@ -480,7 +326,6 @@ def calculate_and_emit_result(match_id):
         
         db.session.commit()
         
-        # Emit result to both players
         socketio.emit('match_result', {
             'creator_move': match.creator_move,
             'joiner_move': match.joiner_move,
@@ -488,9 +333,7 @@ def calculate_and_emit_result(match_id):
             'creator_coins': creator.coins,
             'joiner_coins': joiner.coins,
             'can_rematch': (creator.coins >= stake and joiner.coins >= stake)
-        }, room=match_id)
-        
-        logger.info(f"Match {match_id} finished. Result: {result}")
+        }, room=match.id)
     except Exception as e:
         logger.exception(f"Error calculating result for match {match_id}")
 
@@ -501,33 +344,25 @@ def on_join_match_room(data):
         match_id = data.get('match_id')
         
         if not session_id or not match_id:
-            logger.error(f"Invalid session or match ID in join_match_room: {session_id}, {match_id}")
             return
         
         match = get_match(match_id)
         if not match:
             return
         
-        # Only allow players in the match to join the room
         if session_id not in [match.creator_id, match.joiner_id]:
-            logger.error(f"Player {session_id} not part of match {match_id}")
             return
         
         join_room(match_id)
-        logger.info(f"Player {session_id} joined match room {match_id}")
         
-        # For rematch, the match will already be in playing state
         if match.status == 'waiting' and match.creator_id and match.joiner_id:
-            # Start match
             match.status = 'playing'
             match.started_at = datetime.now(UTC)
             
-            # Deduct stakes
             creator = Player.query.filter_by(session_id=match.creator_id).first()
             joiner = Player.query.filter_by(session_id=match.joiner_id).first()
             
             if not creator or not joiner:
-                logger.error(f"Players not found for match {match_id}")
                 return
             
             creator.coins -= match.stake
@@ -535,18 +370,15 @@ def on_join_match_room(data):
             
             db.session.commit()
             
-            # Start match timer
-            if match.id in match_timers and match_timers[match.id]:
+            if match.id in match_timers:
                 match_timers[match.id].cancel()
             match_timers[match.id] = Timer(30, handle_match_timeout, args=[match.id])
             match_timers[match.id].start()
             
-            # Notify players
             socketio.emit('match_started', {
                 'match_id': match.id,
                 'stake': match.stake,
                 'is_creator': True,
-                'rematch': True,
                 'creator_coins': creator.coins,
                 'joiner_coins': joiner.coins
             }, room=match.creator_id)
@@ -555,12 +387,9 @@ def on_join_match_room(data):
                 'match_id': match.id,
                 'stake': match.stake,
                 'is_creator': False,
-                'rematch': True,
                 'creator_coins': creator.coins,
                 'joiner_coins': joiner.coins
             }, room=match.joiner_id)
-            
-            logger.info(f"Match {match_id} started")
     except Exception as e:
         logger.exception("Error in join_match_room handler")
 
@@ -571,13 +400,30 @@ def on_leave_match_room(data):
         match_id = data.get('match_id')
         
         if not session_id or not match_id:
-            logger.error(f"Invalid session or match ID in leave_match_room: {session_id}, {match_id}")
             return
         
         leave_room(match_id)
-        logger.info(f"Player {session_id} left match room {match_id}")
     except Exception as e:
         logger.exception("Error in leave_match_room handler")
+
+def handle_match_timeout(match_id):
+    try:
+        match = get_match(match_id)
+        if not match or match.status != 'playing':
+            return
+        
+        if not match.creator_move:
+            match.creator_move = random_move()
+            socketio.emit('move_made', {'player': 'creator', 'auto': True}, room=match_id)
+        
+        if not match.joiner_move:
+            match.joiner_move = random_move()
+            socketio.emit('move_made', {'player': 'joiner', 'auto': True}, room=match_id)
+        
+        db.session.commit()
+        calculate_and_emit_result(match_id)
+    except Exception as e:
+        logger.exception(f"Error in match timeout handler for match {match_id}")
 
 @socketio.on('rematch_accepted')
 def on_rematch_accepted(data):
@@ -586,14 +432,12 @@ def on_rematch_accepted(data):
         match_id = data.get('match_id')
         
         if not session_id or not match_id:
-            logger.error(f"Invalid session or match ID in rematch_accepted: {session_id}, {match_id}")
             return
         
         match = get_match(match_id)
         if not match:
             return
         
-        # Check if both players have enough coins for rematch
         creator = Player.query.filter_by(session_id=match.creator_id).first()
         joiner = Player.query.filter_by(session_id=match.joiner_id).first()
         
@@ -601,7 +445,6 @@ def on_rematch_accepted(data):
             return
         
         if creator.coins < match.stake or joiner.coins < match.stake:
-            logger.error(f"Insufficient coins for rematch in match {match_id}")
             socketio.emit('rematch_declined', {
                 'reason': 'insufficient_coins'
             }, room=match_id)
@@ -610,14 +453,14 @@ def on_rematch_accepted(data):
         # Update ready state
         if session_id == match.creator_id:
             match.creator_ready = True
-            logger.info(f"Creator {session_id} ready for rematch in match {match_id}")
+            logger.info(f"Creator {session_id} ready for rematch")
         elif session_id == match.joiner_id:
             match.joiner_ready = True
-            logger.info(f"Joiner {session_id} ready for rematch in match {match_id}")
+            logger.info(f"Joiner {session_id} ready for rematch")
         
         db.session.commit()
         
-        # Notify others that a player accepted rematch
+        # Notify others about rematch acceptance
         socketio.emit('rematch_accepted_by_player', {
             'player': 'creator' if session_id == match.creator_id else 'joiner',
             'match_id': match_id
@@ -625,7 +468,7 @@ def on_rematch_accepted(data):
         
         # If both players are ready, start new match
         if match.creator_ready and match.joiner_ready:
-            logger.info(f"Both players ready for rematch in match {match_id}")
+            logger.info(f"Both players ready for rematch")
             
             # Deduct stakes
             creator.coins -= match.stake
@@ -644,20 +487,12 @@ def on_rematch_accepted(data):
             db.session.commit()
             
             # Start match timer
-            if match.id in match_timers and match_timers[match.id]:
+            if match.id in match_timers:
                 match_timers[match.id].cancel()
             match_timers[match.id] = Timer(30, handle_match_timeout, args=[match.id])
             match_timers[match.id].start()
             
-            # Notify about rematch starting
-            socketio.emit('rematch_started', {
-                'match_id': match.id,
-                'stake': match.stake,
-                'creator_coins': creator.coins,
-                'joiner_coins': joiner.coins
-            }, room=match_id)
-            
-            # Then start the match for each player
+            # Notify players about match start
             socketio.emit('match_started', {
                 'match_id': match.id,
                 'stake': match.stake,
@@ -685,7 +520,6 @@ def on_rematch_declined(data):
         match_id = data.get('match_id')
         
         if not session_id or not match_id:
-            logger.error(f"Invalid session or match ID in rematch_declined: {session_id}, {match_id}")
             return
         
         match = get_match(match_id)
@@ -697,7 +531,6 @@ def on_rematch_declined(data):
         match.joiner_ready = False
         db.session.commit()
         
-        # Notify others that a player declined rematch
         socketio.emit('rematch_declined', {}, room=match_id)
     except Exception as e:
         logger.exception("Error in rematch_declined handler")

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,9 +153,8 @@
         let matches = {};  // Store match states
         let rematchTimer = null;
         let lastMatchStake = null;  // Store stake for rematch
-        let hasAcceptedRematch = false;  // Track if player has accepted rematch
 
-        // Initialize socket connection with logging
+        // Initialize socket connection
         socket = io({
             transports: ['websocket'],
             upgrade: false,
@@ -193,25 +192,13 @@
                 const data = await response.json();
                 
                 // Update coin balance and stats
-                const coinBalance = document.getElementById('coinBalance');
-                if (coinBalance) {
-                    coinBalance.textContent = data.coins;
-                }
+                document.getElementById('coinBalance').textContent = data.coins;
 
                 if (data.stats) {
-                    const elements = {
-                        'playerWins': data.stats.wins,
-                        'playerLosses': data.stats.losses,
-                        'playerDraws': data.stats.draws,
-                        'totalCoinsWon': data.stats.total_coins_won
-                    };
-
-                    for (const [id, value] of Object.entries(elements)) {
-                        const element = document.getElementById(id);
-                        if (element) {
-                            element.textContent = value;
-                        }
-                    }
+                    document.getElementById('playerWins').textContent = data.stats.wins;
+                    document.getElementById('playerLosses').textContent = data.stats.losses;
+                    document.getElementById('playerDraws').textContent = data.stats.draws;
+                    document.getElementById('totalCoinsWon').textContent = data.stats.total_coins_won;
                 }
                 
                 // Update match list
@@ -250,16 +237,9 @@
                         }
                     }
                     // Only change screens if not in result screen during rematch
-                    else if (data.current_match.status === 'waiting') {
-                        if (!document.getElementById('waitingScreen').classList.contains('active') &&
-                            !document.getElementById('resultScreen').classList.contains('active')) {
-                            showScreen('waitingScreen');
-                        }
-                    } else if (data.current_match.status === 'playing') {
-                        if (!document.getElementById('playScreen').classList.contains('active')) {
-                            showScreen('playScreen');
-                            startMoveTimer();
-                        }
+                    else if (data.current_match.status === 'playing') {
+                        showScreen('playScreen');
+                        startMoveTimer();
                     }
                 }
             } catch (error) {
@@ -273,23 +253,13 @@
             document.querySelectorAll('.screen').forEach(screen => {
                 screen.classList.remove('active');
             });
-            const targetScreen = document.getElementById(screenId);
-            if (targetScreen) {
-                targetScreen.classList.add('active');
-            } else {
-                console.error('Screen not found:', screenId);
-            }
+            document.getElementById(screenId).classList.add('active');
         }
 
         function startMoveTimer() {
             let timeLeft = 10;
             const timerElement = document.getElementById('moveTimer');
             const timerRing = document.querySelector('.timer-ring');
-            
-            if (!timerElement || !timerRing) {
-                console.error('Timer elements not found');
-                return;
-            }
             
             function updateTimer() {
                 timerElement.textContent = timeLeft;
@@ -313,10 +283,8 @@
                 }
             }
             
-            // Clear any existing timer
             stopMoveTimer();
             
-            // Reset timer elements
             timerElement.classList.remove('animate__headShake', 'animate__bounceOut');
             timerElement.style.color = 'var(--warning-color)';
             document.querySelectorAll('.move-btn').forEach(btn => {
@@ -363,11 +331,6 @@
         // Match functions
         window.joinMatch = async function(matchId) {
             try {
-                if (!socket || !socket.connected) {
-                    throw new Error('Socket not connected');
-                }
-
-                console.log('Joining match:', matchId);
                 const response = await fetch('/api/join_match', {
                     method: 'POST',
                     headers: {
@@ -379,21 +342,15 @@
                 });
                 
                 if (!response.ok) {
-                    const errorData = await response.json();
-                    throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+                    throw new Error((await response.json()).error || `HTTP error! status: ${response.status}`);
                 }
                 
                 const data = await response.json();
                 if (data.success) {
                     currentMatchId = matchId;
                     isCreator = false;
-                    hasAcceptedRematch = false;
 
-                    // Join the match room via socket
-                    console.log('Joining match room:', matchId);
                     socket.emit('join_match_room', { match_id: matchId });
-
-                    // Show waiting screen
                     showScreen('waitingScreen');
                 }
             } catch (error) {
@@ -410,74 +367,59 @@
             const stakePreview = document.getElementById('stakePreview');
             const confirmStakeBtn = document.getElementById('confirmStakeBtn');
 
-            if (createMatchBtn) {
-                createMatchBtn.onclick = () => {
-                    createMatchForm.style.display = 'block';
-                    createMatchBtn.style.display = 'none';
-                    createMatchForm.classList.add('animate__fadeIn');
-                };
-            }
+            createMatchBtn.onclick = () => {
+                createMatchForm.style.display = 'block';
+                createMatchBtn.style.display = 'none';
+                createMatchForm.classList.add('animate__fadeIn');
+            };
 
-            if (stakeInput) {
-                stakeInput.oninput = () => {
-                    stakePreview.textContent = stakeInput.value || '0';
-                };
-            }
+            stakeInput.oninput = () => {
+                stakePreview.textContent = stakeInput.value || '0';
+            };
 
-            if (confirmStakeBtn) {
-                confirmStakeBtn.onclick = async () => {
-                    const stake = parseInt(stakeInput.value);
-                    if (!stake || stake <= 0) {
-                        alert('Please enter a valid stake amount');
-                        return;
+            confirmStakeBtn.onclick = async () => {
+                const stake = parseInt(stakeInput.value);
+                if (!stake || stake <= 0) {
+                    alert('Please enter a valid stake amount');
+                    return;
+                }
+
+                try {
+                    const response = await fetch('/api/create_match', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'Accept': 'application/json'
+                        },
+                        body: JSON.stringify({stake}),
+                        credentials: 'same-origin'
+                    });
+
+                    if (!response.ok) {
+                        throw new Error((await response.json()).error || `HTTP error! status: ${response.status}`);
                     }
 
-                    try {
-                        const response = await fetch('/api/create_match', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'Accept': 'application/json'
-                            },
-                            body: JSON.stringify({stake}),
-                            credentials: 'same-origin'
-                        });
+                    const data = await response.json();
+                    currentMatchId = data.match_id;
+                    isCreator = true;
 
-                        if (!response.ok) {
-                            const errorData = await response.json();
-                            throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
-                        }
-
-                        const data = await response.json();
-                        currentMatchId = data.match_id;
-                        isCreator = true;
-                        hasAcceptedRematch = false;
-
-                        // Join the match room via socket
-                        socket.emit('join_match_room', { match_id: currentMatchId });
-
-                        // Show waiting screen
-                        showScreen('waitingScreen');
-                    } catch (error) {
-                        console.error('Error creating match:', error);
-                        alert(error.message);
-                    }
-                };
-            }
+                    socket.emit('join_match_room', { match_id: currentMatchId });
+                    showScreen('waitingScreen');
+                } catch (error) {
+                    console.error('Error creating match:', error);
+                    alert(error.message);
+                }
+            };
 
             // Back to lobby button handler
-            const backToLobbyBtn = document.getElementById('backToLobbyBtn');
-            if (backToLobbyBtn) {
-                backToLobbyBtn.onclick = () => {
-                    if (currentMatchId) {
-                        socket.emit('leave_match_room', { match_id: currentMatchId });
-                    }
-                    currentMatchId = null;
-                    isCreator = false;
-                    hasAcceptedRematch = false;
-                    showScreen('lobbyScreen');
-                };
-            }
+            document.getElementById('backToLobbyBtn').onclick = () => {
+                if (currentMatchId) {
+                    socket.emit('leave_match_room', { match_id: currentMatchId });
+                }
+                currentMatchId = null;
+                isCreator = false;
+                showScreen('lobbyScreen');
+            };
 
             // Move buttons handler
             document.querySelectorAll('.move-btn').forEach(button => {
@@ -495,18 +437,13 @@
                         });
 
                         if (!response.ok) {
-                            const errorData = await response.json();
-                            throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+                            throw new Error((await response.json()).error || `HTTP error! status: ${response.status}`);
                         }
 
-                        // Disable all move buttons and update status
                         document.querySelectorAll('.move-btn').forEach(btn => {
                             btn.disabled = true;
                         });
-                        const status = document.getElementById('playerMoveStatus');
-                        if (status) {
-                            status.textContent = 'Move made: ' + move;
-                        }
+                        document.getElementById('playerMoveStatus').textContent = 'Move made: ' + move;
                     } catch (error) {
                         console.error('Error making move:', error);
                     }
@@ -515,44 +452,29 @@
 
             // Socket event handlers
             socket.on('match_started', (data) => {
-                console.log('Match started event received:', data);
+                console.log('Match started:', data);
                 currentMatchId = data.match_id;
                 isCreator = data.is_creator;
 
-                // If this is a rematch, show a message
-                if (data.rematch) {
-                    const notification = document.createElement('div');
-                    notification.className = 'notification animate__animated animate__fadeIn';
-                    notification.textContent = 'Rematch started!';
-                    document.querySelector('.container').appendChild(notification);
-                    setTimeout(() => {
-                        notification.classList.add('animate__fadeOut');
-                        setTimeout(() => notification.remove(), 1000);
-                    }, 2000);
-                }
-
-                // Show play screen and start timer
                 showScreen('playScreen');
                 startMoveTimer();
             });
 
             socket.on('move_made', (data) => {
-                console.log('Move made event received:', data);
+                console.log('Move made:', data);
                 const isOpponent = (data.player === 'creator' && !isCreator) ||
                                  (data.player === 'joiner' && isCreator);
                 if (isOpponent) {
                     const status = document.getElementById('opponentMoveStatus');
-                    if (status) {
-                        status.classList.add('animate__animated', 'animate__fadeIn');
-                        status.textContent = data.auto ?
-                            'Opponent move was random (timeout)' :
-                            'Opponent made their move';
-                    }
+                    status.classList.add('animate__animated', 'animate__fadeIn');
+                    status.textContent = data.auto ?
+                        'Opponent move was random (timeout)' :
+                        'Opponent made their move';
                 }
             });
 
             socket.on('match_result', (data) => {
-                console.log('Match result event received:', data);
+                console.log('Match result:', data);
                 stopMoveTimer();
 
                 const playerMove = isCreator ? data.creator_move : data.joiner_move;
@@ -562,39 +484,34 @@
                 const playerMoveElement = document.getElementById('playerMove');
                 const opponentMoveElement = document.getElementById('opponentMove');
 
-                if (playerMoveElement && opponentMoveElement) {
-                    playerMoveElement.classList.add('animate__animated', 'animate__bounceIn');
-                    playerMoveElement.innerHTML = `
-                        <span class="move-icon">${getMoveIcon(playerMove)}</span>
-                        <span class="move-text">${playerMove}</span>
-                    `;
+                playerMoveElement.classList.add('animate__animated', 'animate__bounceIn');
+                playerMoveElement.innerHTML = `
+                    <span class="move-icon">${getMoveIcon(playerMove)}</span>
+                    <span class="move-text">${playerMove}</span>
+                `;
 
-                    opponentMoveElement.classList.add('animate__animated', 'animate__bounceIn');
-                    opponentMoveElement.innerHTML = `
-                        <span class="move-icon">${getMoveIcon(opponentMove)}</span>
-                        <span class="move-text">${opponentMove}</span>
-                    `;
-                }
+                opponentMoveElement.classList.add('animate__animated', 'animate__bounceIn');
+                opponentMoveElement.innerHTML = `
+                    <span class="move-icon">${getMoveIcon(opponentMove)}</span>
+                    <span class="move-text">${opponentMove}</span>
+                `;
 
                 // Update result text
                 const resultText = document.getElementById('resultText');
-                if (resultText) {
-                    let result = '';
-                    if (data.result === 'draw') {
-                        result = "It's a draw!";
-                    } else {
-                        const isWinner = (data.result === 'player1' && isCreator) ||
-                                       (data.result === 'player2' && !isCreator);
-                        result = isWinner ? 'You won!' : 'You lost!';
-                    }
-                    resultText.textContent = result;
-                    resultText.classList.add('animate__animated',
-                        data.result === 'draw' ? 'animate__bounce' :
-                        result === 'You won!' ? 'animate__tada' : 'animate__wobble'
-                    );
+                let result = '';
+                if (data.result === 'draw') {
+                    result = "It's a draw!";
+                } else {
+                    const isWinner = (data.result === 'player1' && isCreator) ||
+                                   (data.result === 'player2' && !isCreator);
+                    result = isWinner ? 'You won!' : 'You lost!';
                 }
+                resultText.textContent = result;
+                resultText.classList.add('animate__animated',
+                    data.result === 'draw' ? 'animate__bounce' :
+                    result === 'You won!' ? 'animate__tada' : 'animate__wobble'
+                );
 
-                // Show result screen
                 showScreen('resultScreen');
 
                 // Handle rematch
@@ -602,28 +519,18 @@
                 const rematchBtn = document.getElementById('rematchBtn');
                 const rematchStatus = document.getElementById('rematchStatus');
 
-                // Reset rematch button state
-                if (rematchBtn) {
+                if (data.can_rematch) {
+                    rematchBtn.style.display = 'block';
                     rematchBtn.disabled = false;
                     rematchBtn.classList.remove('animate__pulse', 'animate__infinite');
                     rematchBtn.innerHTML = `
                         <span class="btn-icon">🔄</span>
                         Rematch (<span id="rematchTimer">15</span>s)
                     `;
-                }
-
-                // Only show rematch button if player has enough coins
-                if (data.can_rematch) {
-                    if (rematchBtn) {
-                        rematchBtn.style.display = 'block';
-                    }
                     
                     let timeLeft = 15;
-
-                    // Clear any existing timer
                     stopRematchTimer();
 
-                    // Start rematch timer
                     const updateTimer = () => {
                         timeLeft--;
                         const timerDisplay = document.getElementById('rematchTimer');
@@ -638,10 +545,7 @@
 
                         if (timeLeft <= 0) {
                             clearInterval(rematchTimer);
-                            if (rematchBtn) {
-                                rematchBtn.classList.remove('animate__headShake');
-                                rematchBtn.style.display = 'none';
-                            }
+                            rematchBtn.style.display = 'none';
                             if (rematchStatus) {
                                 rematchStatus.textContent = 'Rematch time expired';
                                 rematchStatus.classList.add('animate__animated', 'animate__fadeOut');
@@ -650,83 +554,51 @@
                                     rematchStatus.classList.remove('animate__fadeOut');
                                 }, 2000);
                             }
-                            if (!hasAcceptedRematch) {
-                                socket.emit('rematch_declined', { match_id: currentMatchId });
-                            }
+                            socket.emit('rematch_declined', { match_id: currentMatchId });
                         }
                     };
 
-                    // Start interval
                     rematchTimer = setInterval(updateTimer, 1000);
 
-                    // Handle rematch button click
-                    if (rematchBtn) {
-                        rematchBtn.onclick = () => {
-                            hasAcceptedRematch = true;
-                            socket.emit('rematch_accepted', { match_id: currentMatchId });
-                            rematchBtn.disabled = true;
-                            rematchBtn.innerHTML = `
-                                <span class="btn-icon">🔄</span>
-                                Waiting for opponent...
-                            `;
-                            if (rematchStatus) {
-                                rematchStatus.textContent = 'Waiting for opponent to accept rematch...';
-                            }
-                        };
-                    }
+                    rematchBtn.onclick = () => {
+                        socket.emit('rematch_accepted', { match_id: currentMatchId });
+                        rematchBtn.disabled = true;
+                        rematchBtn.innerHTML = `
+                            <span class="btn-icon">🔄</span>
+                            Waiting for opponent...
+                        `;
+                        rematchStatus.textContent = 'Waiting for opponent to accept rematch...';
+                    };
                 } else {
-                    if (rematchStatus) {
-                        rematchStatus.textContent = 'Not enough coins for rematch';
-                    }
+                    rematchStatus.textContent = 'Not enough coins for rematch';
                 }
             });
 
             socket.on('rematch_accepted_by_player', (data) => {
-                console.log('Player accepted rematch:', data);
+                console.log('Rematch accepted by player:', data);
                 const rematchStatus = document.getElementById('rematchStatus');
                 const rematchBtn = document.getElementById('rematchBtn');
 
-                if (rematchStatus) {
-                    if (data.player === 'creator' && !isCreator || data.player === 'joiner' && isCreator) {
-                        rematchStatus.textContent = 'Opponent wants a rematch! Accept?';
-                        if (rematchBtn && !rematchBtn.disabled && !hasAcceptedRematch) {
-                            rematchBtn.classList.add('animate__animated', 'animate__pulse', 'animate__infinite');
-                        }
+                if (data.player === 'creator' && !isCreator || data.player === 'joiner' && isCreator) {
+                    rematchStatus.textContent = 'Opponent wants a rematch! Accept?';
+                    if (rematchBtn && !rematchBtn.disabled) {
+                        rematchBtn.classList.add('animate__animated', 'animate__pulse', 'animate__infinite');
                     }
                 }
             });
 
             socket.on('rematch_declined', (data) => {
-                console.log('Opponent declined rematch:', data);
+                console.log('Rematch declined:', data);
                 const rematchBtn = document.getElementById('rematchBtn');
                 const rematchStatus = document.getElementById('rematchStatus');
 
-                if (rematchBtn) {
-                    rematchBtn.style.display = 'none';
-                }
-
-                if (rematchStatus) {
-                    rematchStatus.textContent = 'Opponent declined rematch';
-                    rematchStatus.classList.add('animate__animated', 'animate__fadeOut');
-                    setTimeout(() => {
-                        rematchStatus.textContent = '';
-                        rematchStatus.classList.remove('animate__fadeOut');
-                    }, 2000);
-                }
-
-                hasAcceptedRematch = false;
-            });
-
-            socket.on('rematch_started', (data) => {
-                console.log('Rematch started:', data);
-                currentMatchId = data.match_id;
-
-                // Stop rematch timer
-                stopRematchTimer();
-
-                // Show play screen and start timer
-                showScreen('playScreen');
-                startMoveTimer();
+                rematchBtn.style.display = 'none';
+                rematchStatus.textContent = 'Opponent declined rematch';
+                rematchStatus.classList.add('animate__animated', 'animate__fadeOut');
+                setTimeout(() => {
+                    rematchStatus.textContent = '';
+                    rematchStatus.classList.remove('animate__fadeOut');
+                }, 2000);
             });
 
             // Initial state update

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,6 +153,7 @@
         let matches = {};  // Store match states
         let rematchTimer = null;
         let lastMatchStake = null;  // Store stake for rematch
+        let hasAcceptedRematch = false;  // Track if player has accepted rematch
 
         // Initialize socket connection with logging
         socket = io({
@@ -215,7 +216,7 @@
                 
                 // Update match list
                 const matchList = document.getElementById('matchList');
-                if (matchList) {
+                if (matchList && document.getElementById('lobbyScreen').classList.contains('active')) {
                     matchList.innerHTML = '';
                     data.open_matches.forEach(match => {
                         const matchDiv = document.createElement('div');
@@ -233,15 +234,31 @@
                     currentMatchId = data.current_match.id;
                     isCreator = data.current_match.is_creator;
 
-                    // Show appropriate screen based on match status
-                    if (data.current_match.status === 'waiting') {
-                        if (!document.getElementById('waitingScreen').classList.contains('active')) {
+                    // Update rematch button state based on server state
+                    if (data.current_match.status === 'finished') {
+                        const rematchBtn = document.getElementById('rematchBtn');
+                        const rematchStatus = document.getElementById('rematchStatus');
+                        
+                        if (isCreator && data.current_match.creator_ready || !isCreator && data.current_match.joiner_ready) {
+                            if (rematchBtn) {
+                                rematchBtn.disabled = true;
+                                rematchBtn.innerHTML = `
+                                    <span class="btn-icon">🔄</span>
+                                    Waiting for opponent...
+                                `;
+                            }
+                        }
+                    }
+                    // Only change screens if not in result screen during rematch
+                    else if (data.current_match.status === 'waiting') {
+                        if (!document.getElementById('waitingScreen').classList.contains('active') &&
+                            !document.getElementById('resultScreen').classList.contains('active')) {
                             showScreen('waitingScreen');
                         }
                     } else if (data.current_match.status === 'playing') {
-                        if (!document.getElementById('playScreen').classList.contains('active') &&
-                            !document.getElementById('resultScreen').classList.contains('active')) {
+                        if (!document.getElementById('playScreen').classList.contains('active')) {
                             showScreen('playScreen');
+                            startMoveTimer();
                         }
                     }
                 }
@@ -370,81 +387,52 @@
                 if (data.success) {
                     currentMatchId = matchId;
                     isCreator = false;
-                    
+                    hasAcceptedRematch = false;
+
                     // Join the match room via socket
                     console.log('Joining match room:', matchId);
                     socket.emit('join_match_room', { match_id: matchId });
-                    
+
                     // Show waiting screen
                     showScreen('waitingScreen');
-                    
-                    // Wait a bit to ensure room is joined before signaling ready
-                    setTimeout(() => {
-                        if (currentMatchId === matchId) {  // Make sure we're still in the same match
-                            console.log('Signaling ready for match:', matchId);
-                            socket.emit('ready_for_match', { match_id: matchId });
-                        }
-                    }, 1000);
-                } else if (data.error) {
-                    throw new Error(data.error);
                 }
             } catch (error) {
                 console.error('Error joining match:', error);
-                alert(error.message || 'Failed to join match. Please try again.');
-                // Reset state on error
-                currentMatchId = null;
-                isCreator = false;
-                showScreen('lobbyScreen');
             }
         };
 
-        // Event handlers
-        document.addEventListener('DOMContentLoaded', function() {
-            // Initialize UI and event handlers
+        // Socket event handlers
+        document.addEventListener('DOMContentLoaded', () => {
+            // Create match button handler
             const createMatchBtn = document.getElementById('createMatchBtn');
-            if (createMatchBtn) {
-                createMatchBtn.addEventListener('click', function() {
-                    const form = document.getElementById('createMatchForm');
-                    if (form) {
-                        if (form.style.display === 'block') {
-                            form.style.display = 'none';
-                            form.classList.remove('animate__fadeIn');
-                        } else {
-                            form.style.display = 'block';
-                            form.classList.add('animate__fadeIn');
-                        }
-                    } else {
-                        console.error('Create match form not found');
-                    }
-                });
-            }
-
-            // Update stake preview
+            const createMatchForm = document.getElementById('createMatchForm');
             const stakeInput = document.getElementById('stakeInput');
-            if (stakeInput) {
-                stakeInput.addEventListener('input', (e) => {
-                    const value = parseInt(e.target.value) || 0;
-                    const preview = document.getElementById('stakePreview');
-                    if (preview) {
-                        preview.textContent = value;
-                    }
-                });
+            const stakePreview = document.getElementById('stakePreview');
+            const confirmStakeBtn = document.getElementById('confirmStakeBtn');
+
+            if (createMatchBtn) {
+                createMatchBtn.onclick = () => {
+                    createMatchForm.style.display = 'block';
+                    createMatchBtn.style.display = 'none';
+                    createMatchForm.classList.add('animate__fadeIn');
+                };
             }
 
-            // Confirm stake
-            const confirmStakeBtn = document.getElementById('confirmStakeBtn');
-            if (confirmStakeBtn) {
-                confirmStakeBtn.addEventListener('click', async function() {
-                    const stakeInput = document.getElementById('stakeInput');
-                    const stake = parseInt(stakeInput.value);
+            if (stakeInput) {
+                stakeInput.oninput = () => {
+                    stakePreview.textContent = stakeInput.value || '0';
+                };
+            }
 
+            if (confirmStakeBtn) {
+                confirmStakeBtn.onclick = async () => {
+                    const stake = parseInt(stakeInput.value);
                     if (!stake || stake <= 0) {
                         alert('Please enter a valid stake amount');
                         return;
                     }
 
                     try {
-                        console.log('Creating match with stake:', stake);
                         const response = await fetch('/api/create_match', {
                             method: 'POST',
                             headers: {
@@ -455,63 +443,46 @@
                             credentials: 'same-origin'
                         });
 
-                        console.log('Create match response status:', response.status);
-                        const data = await response.json();
-                        console.log('Create match response data:', data);
-
-                        if (response.ok && data.match_id) {
-                            currentMatchId = data.match_id;
-                            isCreator = true;
-
-                            // Join the match room via socket
-                            console.log('Joining match room:', data.match_id);
-                            socket.emit('join_match_room', { match_id: data.match_id });
-                            
-                            // Wait a bit to ensure room is joined before signaling ready
-                            setTimeout(() => {
-                                if (currentMatchId === data.match_id) {  // Make sure we're still in the same match
-                                    console.log('Signaling ready for match:', data.match_id);
-                                    socket.emit('ready_for_match', { match_id: data.match_id });
-                                }
-                            }, 1000);
-
-                            const form = document.getElementById('createMatchForm');
-                            if (form) {
-                                form.classList.remove('animate__fadeIn');
-                                form.classList.add('animate__fadeOut');
-                                setTimeout(() => {
-                                    form.style.display = 'none';
-                                    form.classList.remove('animate__fadeOut');
-                                    stakeInput.value = '';
-                                    const preview = document.getElementById('stakePreview');
-                                    if (preview) preview.textContent = '0';
-                                    showScreen('waitingScreen');
-                                }, 500);
-                            } else {
-                                console.error('Form not found');
-                                showScreen('waitingScreen');
-                            }
-                        } else {
-                            const errorMessage = data.error || 'Failed to create match';
-                            console.error('Error creating match:', errorMessage);
-                            alert(errorMessage);
+                        if (!response.ok) {
+                            const errorData = await response.json();
+                            throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
                         }
+
+                        const data = await response.json();
+                        currentMatchId = data.match_id;
+                        isCreator = true;
+                        hasAcceptedRematch = false;
+
+                        // Join the match room via socket
+                        socket.emit('join_match_room', { match_id: currentMatchId });
+
+                        // Show waiting screen
+                        showScreen('waitingScreen');
                     } catch (error) {
                         console.error('Error creating match:', error);
-                        alert('Failed to create match. Please try again.');
+                        alert(error.message);
                     }
-                });
+                };
             }
 
-            // Make move
-            document.querySelectorAll('.move-btn').forEach(btn => {
-                btn.addEventListener('click', async () => {
-                    const move = btn.dataset.move;
-                    
-                    // Animate the clicked button
-                    btn.classList.add('animate__rubberBand');
-                    setTimeout(() => btn.classList.remove('animate__rubberBand'), 1000);
-                    
+            // Back to lobby button handler
+            const backToLobbyBtn = document.getElementById('backToLobbyBtn');
+            if (backToLobbyBtn) {
+                backToLobbyBtn.onclick = () => {
+                    if (currentMatchId) {
+                        socket.emit('leave_match_room', { match_id: currentMatchId });
+                    }
+                    currentMatchId = null;
+                    isCreator = false;
+                    hasAcceptedRematch = false;
+                    showScreen('lobbyScreen');
+                };
+            }
+
+            // Move buttons handler
+            document.querySelectorAll('.move-btn').forEach(button => {
+                button.onclick = async () => {
+                    const move = button.dataset.move;
                     try {
                         const response = await fetch('/api/move', {
                             method: 'POST',
@@ -522,123 +493,59 @@
                             body: JSON.stringify({move}),
                             credentials: 'same-origin'
                         });
-                        
+
                         if (!response.ok) {
-                            throw new Error(`HTTP error! status: ${response.status}`);
+                            const errorData = await response.json();
+                            throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
                         }
-                        
-                        const data = await response.json();
-                        if (data.success) {
-                            // Disable and fade out other buttons
-                            document.querySelectorAll('.move-btn').forEach(b => {
-                                if (b !== btn) {
-                                    b.classList.add('animate__fadeOut');
-                                    setTimeout(() => b.style.visibility = 'hidden', 500);
-                                }
-                                b.disabled = true;
-                            });
-                            
-                            // Update status with animation
-                            const status = document.getElementById('playerMoveStatus');
-                            status.classList.add('animate__animated', 'animate__fadeIn');
+
+                        // Disable all move buttons and update status
+                        document.querySelectorAll('.move-btn').forEach(btn => {
+                            btn.disabled = true;
+                        });
+                        const status = document.getElementById('playerMoveStatus');
+                        if (status) {
                             status.textContent = 'Move made: ' + move;
-                            
-                            // Show player's move with animation
-                            const playerMove = document.getElementById('playerMove');
-                            playerMove.classList.add('animate__animated', 'animate__bounceIn');
-                            playerMove.innerHTML = `
-                                <span class="move-icon">${getMoveIcon(move)}</span>
-                                <span class="move-text">${move}</span>
-                            `;
                         }
                     } catch (error) {
                         console.error('Error making move:', error);
-                        alert('Failed to make move. Please try again.');
                     }
-                });
+                };
             });
 
-            // Back to lobby
-            const backToLobbyBtn = document.getElementById('backToLobbyBtn');
-            if (backToLobbyBtn) {
-                backToLobbyBtn.addEventListener('click', () => {
-                    showScreen('lobbyScreen');
-                    updateGameState();
-                });
-            }
-
-            // Socket events
-            socket.on('match_error', (data) => {
-                console.error('Match error:', data);
-                alert(data.error);
-                showScreen('lobbyScreen');
-                updateGameState();
-            });
-
+            // Socket event handlers
             socket.on('match_started', (data) => {
                 console.log('Match started event received:', data);
-                if (data.match_id === currentMatchId) {
-                    // Reset game state
-                    matches[currentMatchId] = {
-                        status: 'playing',
-                        start_time: data.start_time
-                    };
-                    
-                    // Show play screen with animation
-                    const playScreen = document.getElementById('playScreen');
-                    playScreen.classList.add('animate__animated', 'animate__fadeIn');
-                    showScreen('playScreen');
-                    
-                    // Start timer
-                    startMoveTimer();
-                    
-                    // Reset and show move buttons with animation
-                    document.querySelectorAll('.move-btn').forEach((btn, index) => {
-                        btn.disabled = false;
-                        btn.style.visibility = 'visible';
-                        btn.classList.remove('animate__fadeOut');
-                        setTimeout(() => {
-                            btn.classList.add('animate__bounceIn');
-                        }, index * 200);
-                    });
-                    
-                    // Reset status messages with animation
-                    const messages = [
-                        document.getElementById('playerMoveStatus'),
-                        document.getElementById('opponentMoveStatus')
-                    ];
-                    messages.forEach(msg => {
-                        if (msg) {
-                            msg.classList.add('animate__animated', 'animate__fadeIn');
-                            msg.textContent = msg.id === 'playerMoveStatus' ? 
-                                'Waiting for your move...' : 'Waiting for opponent to move...';
-                        }
-                    });
-                    
-                    // If this is a rematch, show a message
-                    if (data.rematch) {
-                        const notification = document.createElement('div');
-                        notification.className = 'notification animate__animated animate__fadeIn';
-                        notification.textContent = 'Rematch started!';
-                        document.querySelector('.container').appendChild(notification);
-                        setTimeout(() => {
-                            notification.classList.add('animate__fadeOut');
-                            setTimeout(() => notification.remove(), 1000);
-                        }, 2000);
-                    }
+                currentMatchId = data.match_id;
+                isCreator = data.is_creator;
+
+                // If this is a rematch, show a message
+                if (data.rematch) {
+                    const notification = document.createElement('div');
+                    notification.className = 'notification animate__animated animate__fadeIn';
+                    notification.textContent = 'Rematch started!';
+                    document.querySelector('.container').appendChild(notification);
+                    setTimeout(() => {
+                        notification.classList.add('animate__fadeOut');
+                        setTimeout(() => notification.remove(), 1000);
+                    }, 2000);
                 }
+
+                // Show play screen and start timer
+                showScreen('playScreen');
+                startMoveTimer();
             });
 
             socket.on('move_made', (data) => {
                 console.log('Move made event received:', data);
-                const isOpponent = (data.player === 'creator' && !isCreator) || 
+                const isOpponent = (data.player === 'creator' && !isCreator) ||
                                  (data.player === 'joiner' && isCreator);
                 if (isOpponent) {
                     const status = document.getElementById('opponentMoveStatus');
                     if (status) {
                         status.classList.add('animate__animated', 'animate__fadeIn');
-                        status.textContent = data.auto ? 
-                            'Opponent move was random (timeout)' : 
+                        status.textContent = data.auto ?
+                            'Opponent move was random (timeout)' :
                             'Opponent made their move';
                     }
                 }
@@ -647,124 +554,88 @@
             socket.on('match_result', (data) => {
                 console.log('Match result event received:', data);
                 stopMoveTimer();
-                
-                const isWinner = (data.winner === 'player1' && isCreator) || 
-                               (data.winner === 'player2' && !isCreator);
-                
-                // Prepare move displays with animations
+
+                const playerMove = isCreator ? data.creator_move : data.joiner_move;
+                const opponentMove = isCreator ? data.joiner_move : data.creator_move;
+
+                // Update move displays
                 const playerMoveElement = document.getElementById('playerMove');
                 const opponentMoveElement = document.getElementById('opponentMove');
-                
+
                 if (playerMoveElement && opponentMoveElement) {
-                    const playerMove = isCreator ? data.creator_move : data.joiner_move;
-                    const opponentMove = isCreator ? data.joiner_move : data.creator_move;
-                    
                     playerMoveElement.classList.add('animate__animated', 'animate__bounceIn');
-                    playerMoveElement.style.animationDelay = '0s';
                     playerMoveElement.innerHTML = `
                         <span class="move-icon">${getMoveIcon(playerMove)}</span>
                         <span class="move-text">${playerMove}</span>
                     `;
-                    
+
                     opponentMoveElement.classList.add('animate__animated', 'animate__bounceIn');
-                    opponentMoveElement.style.animationDelay = '0.5s';
                     opponentMoveElement.innerHTML = `
                         <span class="move-icon">${getMoveIcon(opponentMove)}</span>
                         <span class="move-text">${opponentMove}</span>
                     `;
                 }
-                
-                // Show result with animation
-                setTimeout(() => {
-                    let resultText = '';
-                    const resultAnimation = document.getElementById('resultAnimation');
-                    const resultTextElement = document.getElementById('resultText');
-                    
-                    if (resultAnimation && resultTextElement) {
-                        if (data.winner === 'draw') {
-                            resultText = "It's a draw!";
-                            resultAnimation.innerHTML = '🤝';
-                            resultAnimation.classList.add('animate__animated', 'animate__bounce');
-                        } else if (isWinner) {
-                            resultText = 'You won!';
-                            resultAnimation.innerHTML = '🏆';
-                            resultAnimation.classList.add('animate__animated', 'animate__tada');
-                        } else {
-                            resultText = 'You lost!';
-                            resultAnimation.innerHTML = '💔';
-                            resultAnimation.classList.add('animate__animated', 'animate__wobble');
-                        }
-                        
-                        resultTextElement.classList.add('animate__animated', 'animate__fadeInUp');
-                        resultTextElement.textContent = resultText;
+
+                // Update result text
+                const resultText = document.getElementById('resultText');
+                if (resultText) {
+                    let result = '';
+                    if (data.result === 'draw') {
+                        result = "It's a draw!";
+                    } else {
+                        const isWinner = (data.result === 'player1' && isCreator) ||
+                                       (data.result === 'player2' && !isCreator);
+                        result = isWinner ? 'You won!' : 'You lost!';
                     }
-                    
-                    // Show match stats with animation
-                    const stats = data.match_stats;
-                    const statsContainer = document.getElementById('matchStats');
-                    if (statsContainer && stats) {
-                        statsContainer.classList.add('animate__animated', 'animate__fadeIn');
-                        statsContainer.innerHTML = `
-                            <div class="stats-item">
-                                <span>Total Rounds:</span>
-                                <span>${stats.rounds}</span>
-                            </div>
-                            <div class="stats-item">
-                                <span>Creator Wins:</span>
-                                <span>${stats.creator_wins}</span>
-                            </div>
-                            <div class="stats-item">
-                                <span>Joiner Wins:</span>
-                                <span>${stats.joiner_wins}</span>
-                            </div>
-                            <div class="stats-item">
-                                <span>Draws:</span>
-                                <span>${stats.draws}</span>
-                            </div>
-                        `;
-                    }
-                }, 1000);
-                
+                    resultText.textContent = result;
+                    resultText.classList.add('animate__animated',
+                        data.result === 'draw' ? 'animate__bounce' :
+                        result === 'You won!' ? 'animate__tada' : 'animate__wobble'
+                    );
+                }
+
+                // Show result screen
                 showScreen('resultScreen');
-                updateGameState();
 
                 // Handle rematch
                 lastMatchStake = data.stake;
                 const rematchBtn = document.getElementById('rematchBtn');
                 const rematchStatus = document.getElementById('rematchStatus');
-                const rematchTimerDisplay = document.getElementById('rematchTimer');
-                
+
                 // Reset rematch button state
-                rematchBtn.disabled = false;
-                rematchBtn.classList.remove('animate__pulse', 'animate__infinite');
-                rematchBtn.innerHTML = `
-                    <span class="btn-icon">🔄</span>
-                    Rematch (<span id="rematchTimer">15</span>s)
-                `;
-                
+                if (rematchBtn) {
+                    rematchBtn.disabled = false;
+                    rematchBtn.classList.remove('animate__pulse', 'animate__infinite');
+                    rematchBtn.innerHTML = `
+                        <span class="btn-icon">🔄</span>
+                        Rematch (<span id="rematchTimer">15</span>s)
+                    `;
+                }
+
                 // Only show rematch button if player has enough coins
                 if (data.can_rematch) {
-                    rematchBtn.style.display = 'block';
-                    let timeLeft = 15;
+                    if (rematchBtn) {
+                        rematchBtn.style.display = 'block';
+                    }
                     
+                    let timeLeft = 15;
+
                     // Clear any existing timer
                     stopRematchTimer();
-                    
+
                     // Start rematch timer
                     const updateTimer = () => {
                         timeLeft--;
-                        // Get the timer display element again as it might have been recreated
                         const timerDisplay = document.getElementById('rematchTimer');
                         if (timerDisplay) {
                             timerDisplay.textContent = timeLeft;
                         }
-                        
-                        // Add visual feedback for last 5 seconds
+
                         if (timeLeft <= 5 && rematchBtn && !rematchBtn.disabled) {
                             rematchBtn.classList.add('animate__headShake');
                             rematchBtn.style.color = 'var(--danger-color)';
                         }
-                        
+
                         if (timeLeft <= 0) {
                             clearInterval(rematchTimer);
                             if (rematchBtn) {
@@ -779,27 +650,30 @@
                                     rematchStatus.classList.remove('animate__fadeOut');
                                 }, 2000);
                             }
-                            socket.emit('rematch_declined', { match_id: currentMatchId });
+                            if (!hasAcceptedRematch) {
+                                socket.emit('rematch_declined', { match_id: currentMatchId });
+                            }
                         }
                     };
-                    
-                    // Initial timer update
-                    updateTimer();
+
                     // Start interval
                     rematchTimer = setInterval(updateTimer, 1000);
-                    
+
                     // Handle rematch button click
-                    rematchBtn.onclick = () => {
-                        socket.emit('rematch_accepted', { match_id: currentMatchId });
-                        rematchBtn.disabled = true;
-                        rematchBtn.innerHTML = `
-                            <span class="btn-icon">🔄</span>
-                            Waiting for opponent...
-                        `;
-                        if (rematchStatus) {
-                            rematchStatus.textContent = 'Waiting for opponent to accept rematch...';
-                        }
-                    };
+                    if (rematchBtn) {
+                        rematchBtn.onclick = () => {
+                            hasAcceptedRematch = true;
+                            socket.emit('rematch_accepted', { match_id: currentMatchId });
+                            rematchBtn.disabled = true;
+                            rematchBtn.innerHTML = `
+                                <span class="btn-icon">🔄</span>
+                                Waiting for opponent...
+                            `;
+                            if (rematchStatus) {
+                                rematchStatus.textContent = 'Waiting for opponent to accept rematch...';
+                            }
+                        };
+                    }
                 } else {
                     if (rematchStatus) {
                         rematchStatus.textContent = 'Not enough coins for rematch';
@@ -807,16 +681,15 @@
                 }
             });
 
-            // Handle rematch events
             socket.on('rematch_accepted_by_player', (data) => {
                 console.log('Player accepted rematch:', data);
                 const rematchStatus = document.getElementById('rematchStatus');
                 const rematchBtn = document.getElementById('rematchBtn');
-                
+
                 if (rematchStatus) {
                     if (data.player === 'creator' && !isCreator || data.player === 'joiner' && isCreator) {
                         rematchStatus.textContent = 'Opponent wants a rematch! Accept?';
-                        if (rematchBtn && !rematchBtn.disabled) {
+                        if (rematchBtn && !rematchBtn.disabled && !hasAcceptedRematch) {
                             rematchBtn.classList.add('animate__animated', 'animate__pulse', 'animate__infinite');
                         }
                     }
@@ -827,11 +700,11 @@
                 console.log('Opponent declined rematch:', data);
                 const rematchBtn = document.getElementById('rematchBtn');
                 const rematchStatus = document.getElementById('rematchStatus');
-                
+
                 if (rematchBtn) {
                     rematchBtn.style.display = 'none';
                 }
-                
+
                 if (rematchStatus) {
                     rematchStatus.textContent = 'Opponent declined rematch';
                     rematchStatus.classList.add('animate__animated', 'animate__fadeOut');
@@ -840,42 +713,20 @@
                         rematchStatus.classList.remove('animate__fadeOut');
                     }, 2000);
                 }
+
+                hasAcceptedRematch = false;
             });
 
             socket.on('rematch_started', (data) => {
                 console.log('Rematch started:', data);
                 currentMatchId = data.match_id;
-                isCreator = data.is_creator;
-                
+
                 // Stop rematch timer
                 stopRematchTimer();
-                
-                // Clear rematch UI
-                const rematchBtn = document.getElementById('rematchBtn');
-                const rematchStatus = document.getElementById('rematchStatus');
-                if (rematchBtn) {
-                    rematchBtn.style.display = 'none';
-                }
-                if (rematchStatus) {
-                    rematchStatus.textContent = '';
-                }
-                
-                // Clear any existing timers
-                if (rematchTimer) {
-                    clearInterval(rematchTimer);
-                    rematchTimer = null;
-                }
-                
-                // Show waiting screen
-                showScreen('waitingScreen');
-                
-                // Join the match room
-                socket.emit('join_match_room', { match_id: data.match_id });
-                
-                // Signal ready after a short delay
-                setTimeout(() => {
-                    socket.emit('ready_for_match', { match_id: data.match_id });
-                }, 1000);
+
+                // Show play screen and start timer
+                showScreen('playScreen');
+                startMoveTimer();
             });
 
             // Initial state update


### PR DESCRIPTION
This PR fixes several issues with the rematch functionality:

1. Removes duplicate rematch_request handler
2. Fixes rematch state synchronization
3. Adds match_id to rematch_accepted_by_player event
4. Adds rematch_started event before match_started
5. Removes unnecessary time.sleep() delay

These changes should resolve the issues where:
- Players get stuck on the "Waiting for opponent..." screen
- The rematch button remains inactive after being pressed
- The rematch state is not properly synchronized between players