### PR TITLE
Implement correct rematch logic

### DIFF
--- a/rematch_changes.txt
+++ b/rematch_changes.txt
@@ -1,0 +1,116 @@
+@socketio.on("rematch_request")
+def on_rematch_request(data):
+    try:
+        session_id = session.get("session_id")
+        match_id = data.get("match_id")
+
+        if not session_id or not match_id:
+            logger.error(f"Invalid session or match ID in rematch_request: {session_id}, {match_id}")
+            return
+
+        # Lock the match for update
+        match = Match.query.filter_by(id=match_id).with_for_update().first()
+        if not match:
+            logger.error(f"Match {match_id} not found")
+            return
+
+        # Check if match is in finished state
+        if match.status != "finished":
+            logger.error(f"Match {match_id} not in finished state")
+            return
+
+        # Check if both players have enough coins
+        creator = Player.query.filter_by(session_id=match.creator_id).first()
+        joiner = Player.query.filter_by(session_id=match.joiner_id).first()
+
+        if not creator or not joiner:
+            logger.error(f"Players not found for match {match_id}")
+            return
+
+        if creator.coins < match.stake or joiner.coins < match.stake:
+            logger.error(f"Insufficient coins for rematch in match {match_id}")
+            socketio.emit("rematch_declined", {
+                "error": "Insufficient coins"
+            }, room=match_id)
+            return
+
+        # Check if player already accepted rematch
+        if (session_id == match.creator_id and match.creator_ready) or            (session_id == match.joiner_id and match.joiner_ready):
+            logger.error(f"Player {session_id} already accepted rematch")
+            return
+
+        # Update player ready state in the current match
+        if session_id == match.creator_id:
+            match.creator_ready = True
+            logger.info(f"Creator {session_id} ready for rematch in match {match_id}")
+        else:
+            match.joiner_ready = True
+            logger.info(f"Joiner {session_id} ready for rematch in match {match_id}")
+        db.session.commit()
+
+        # Notify others about rematch request status
+        socketio.emit("rematch_status_update", {
+            "match_id": match_id,
+            "creator_ready": match.creator_ready,
+            "joiner_ready": match.joiner_ready,
+            "requesting_player": "creator" if session_id == match.creator_id else "joiner"
+        }, room=match_id)
+
+        # Start a new match only if both players have accepted
+        if match.creator_ready and match.joiner_ready:
+            logger.info(f"Both players ready for rematch in match {match_id}")
+
+            # Create new match with same stake
+            new_match_id = secrets.token_hex(4)
+            new_match = Match(
+                id=new_match_id,
+                creator_id=match.creator_id,  # Keep the same creator for consistency
+                joiner_id=match.joiner_id,
+                stake=match.stake,
+                status="playing",
+                creator_ready=False,
+                joiner_ready=False,
+                started_at=datetime.now(UTC)
+            )
+
+            # Update player references
+            creator.current_match_id = new_match_id
+            joiner.current_match_id = new_match_id
+
+            db.session.add(new_match)
+            db.session.commit()
+
+            # Join both players to the new match room
+            join_room(new_match_id)
+
+            # Set up timer for move timeout
+            def handle_timeout():
+                with app.app_context():
+                    try:
+                        handle_match_timeout(new_match_id)
+                    except Exception as e:
+                        logger.exception(f"Error in match timeout handler for match {new_match_id}")
+
+            # Start new timer
+            match_timers[new_match_id] = Timer(10, handle_timeout)
+            match_timers[new_match_id].start()
+
+            logger.info(f"Rematch started: {new_match_id}")
+
+            # Notify about new match
+            socketio.emit("match_started", {
+                "match_id": new_match_id,
+                "creator_id": new_match.creator_id,
+                "joiner_id": new_match.joiner_id,
+                "stake": new_match.stake,
+                "rematch": True,
+                "time_limit": 10,
+                "start_time": new_match.started_at.isoformat()
+            }, room=new_match_id)
+
+            # Clean up old match
+            db.session.delete(match)
+            db.session.commit()
+
+    except Exception as e:
+        logger.exception("Error in rematch_request handler")

--- a/static/js/game.js
+++ b/static/js/game.js
@@ -1,0 +1,92 @@
+// Socket events for rematch
+socket.on("rematch_status_update", (data) => {
+    console.log("Rematch status update:", data);
+    const rematchBtn = document.getElementById("rematchBtn");
+    const rematchStatus = document.getElementById("rematchStatus");
+
+    if (rematchBtn && rematchStatus) {
+        if ((isCreator && data.creator_ready) || (!isCreator && data.joiner_ready)) {
+            // This player has already requested rematch
+            rematchBtn.disabled = true;
+            rematchBtn.innerHTML = ;
+            rematchStatus.textContent = "Waiting for opponent to accept rematch...";
+        } else if ((isCreator && data.joiner_ready) || (!isCreator && data.creator_ready)) {
+            // Opponent has requested rematch
+            rematchBtn.classList.add("animate__animated", "animate__pulse", "animate__infinite");
+            rematchStatus.textContent = "Opponent wants a rematch! Accept?";
+        }
+    }
+});
+
+socket.on("match_result", (data) => {
+    console.log("Match result event received:", data);
+    stopMoveTimer();
+
+    // Show result screen with animations
+    showScreen("resultScreen");
+    updateGameState();
+
+    // Handle rematch button
+    const rematchBtn = document.getElementById("rematchBtn");
+    const rematchStatus = document.getElementById("rematchStatus");
+
+    if (rematchBtn && rematchStatus) {
+        // Only show rematch button if player has enough coins
+        if (data.can_rematch) {
+            rematchBtn.style.display = "block";
+            rematchBtn.disabled = false;
+            rematchBtn.classList.remove("animate__pulse", "animate__infinite");
+            rematchBtn.innerHTML = ;
+            rematchStatus.textContent = "";
+
+            // Handle rematch button click
+            rematchBtn.onclick = () => {
+                socket.emit("rematch_request", { match_id: currentMatchId });
+                rematchBtn.disabled = true;
+                rematchBtn.innerHTML = ;
+                rematchStatus.textContent = "Waiting for opponent to accept rematch...";
+            };
+        } else {
+            rematchBtn.style.display = "none";
+            rematchStatus.textContent = "Not enough coins for rematch";
+        }
+    }
+});
+
+socket.on("match_started", (data) => {
+    console.log("Match started event received:", data);
+    if (data.match_id === currentMatchId) {
+        // Reset game state
+        matches[currentMatchId] = {
+            status: "playing",
+            start_time: data.start_time
+        };
+
+        // Show play screen with animation
+        showScreen("playScreen");
+        startMoveTimer();
+
+        // Reset move buttons
+        document.querySelectorAll(".move-btn").forEach(btn => {
+            btn.disabled = false;
+            btn.style.visibility = "visible";
+            btn.classList.remove("animate__fadeOut");
+        });
+
+        // Reset status messages
+        document.getElementById("playerMoveStatus").textContent = "Waiting for your move...";
+        document.getElementById("opponentMoveStatus").textContent = "Waiting for opponent to move...";
+
+        // If this is a rematch, show notification
+        if (data.rematch) {
+            const notification = document.createElement("div");
+            notification.className = "notification animate__animated animate__fadeIn";
+            notification.textContent = "Rematch started!";
+            document.querySelector(".container").appendChild(notification);
+            setTimeout(() => {
+                notification.classList.add("animate__fadeOut");
+                setTimeout(() => notification.remove(), 1000);
+            }, 2000);
+        }
+    }
+});

--- a/templates/index.html.bak
+++ b/templates/index.html.bak
@@ -143,7 +143,6 @@
         </div>
     </div>
 
-<script src="/static/js/game.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
     <script>
         // Global variables
@@ -809,3 +808,80 @@
             });
 
             // Handle rematch events
+            socket.on('rematch_accepted_by_player', (data) => {
+                console.log('Player accepted rematch:', data);
+                const rematchStatus = document.getElementById('rematchStatus');
+                const rematchBtn = document.getElementById('rematchBtn');
+                
+                if (rematchStatus) {
+                    if (data.player === 'creator' && !isCreator || data.player === 'joiner' && isCreator) {
+                        rematchStatus.textContent = 'Opponent wants a rematch! Accept?';
+                        if (rematchBtn && !rematchBtn.disabled) {
+                            rematchBtn.classList.add('animate__animated', 'animate__pulse', 'animate__infinite');
+                        }
+                    }
+                }
+            });
+
+            socket.on('rematch_declined', (data) => {
+                console.log('Opponent declined rematch:', data);
+                const rematchBtn = document.getElementById('rematchBtn');
+                const rematchStatus = document.getElementById('rematchStatus');
+                
+                if (rematchBtn) {
+                    rematchBtn.style.display = 'none';
+                }
+                
+                if (rematchStatus) {
+                    rematchStatus.textContent = 'Opponent declined rematch';
+                    rematchStatus.classList.add('animate__animated', 'animate__fadeOut');
+                    setTimeout(() => {
+                        rematchStatus.textContent = '';
+                        rematchStatus.classList.remove('animate__fadeOut');
+                    }, 2000);
+                }
+            });
+
+            socket.on('rematch_started', (data) => {
+                console.log('Rematch started:', data);
+                currentMatchId = data.match_id;
+                isCreator = data.is_creator;
+                
+                // Stop rematch timer
+                stopRematchTimer();
+                
+                // Clear rematch UI
+                const rematchBtn = document.getElementById('rematchBtn');
+                const rematchStatus = document.getElementById('rematchStatus');
+                if (rematchBtn) {
+                    rematchBtn.style.display = 'none';
+                }
+                if (rematchStatus) {
+                    rematchStatus.textContent = '';
+                }
+                
+                // Clear any existing timers
+                if (rematchTimer) {
+                    clearInterval(rematchTimer);
+                    rematchTimer = null;
+                }
+                
+                // Show waiting screen
+                showScreen('waitingScreen');
+                
+                // Join the match room
+                socket.emit('join_match_room', { match_id: data.match_id });
+                
+                // Signal ready after a short delay
+                setTimeout(() => {
+                    socket.emit('ready_for_match', { match_id: data.match_id });
+                }, 1000);
+            });
+
+            // Initial state update
+            updateGameState();
+            setInterval(updateGameState, 5000);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This PR implements the correct rematch logic:

1. The player who first presses the rematch button stays on the results screen with an inactive rematch button
2. When the second player presses rematch, a new match is automatically created
3. The match starts automatically after both players have accepted
4. Rematch is only available if both players have enough balance