### PR TITLE
Fix coin deduction issue

### DIFF
--- a/src/models/player.py
+++ b/src/models/player.py
@@ -33,11 +33,8 @@ class Player:
         return self.coins >= amount
 
     def add_coins(self, amount):
-        self.coins += amount
-        if amount > 0:
-            self.stats.total_coins_won += amount
-        else:
-            self.stats.total_coins_lost += abs(amount)
+        """Deprecated: Use direct coin assignment and stats update instead"""
+        pass
 
     def record_win(self):
         self.stats.wins += 1

--- a/src/services/game_service.py
+++ b/src/services/game_service.py
@@ -52,27 +52,41 @@ class GameService:
         elif result == 'player1':
             match.stats.creator_wins += 1
             players[match.creator].record_win()
-            players[match.creator].add_coins(match.stake)
             players[match.joiner].record_loss()
-            players[match.joiner].add_coins(-match.stake)
-            creator_user.wins += 1
+            
+            # Update coins in one place and sync
             creator_user.coins += match.stake
+            joiner_user.coins -= match.stake
+            players[match.creator].coins = creator_user.coins
+            players[match.joiner].coins = joiner_user.coins
+            
+            # Update stats
+            players[match.creator].stats.total_coins_won += match.stake
+            players[match.joiner].stats.total_coins_lost += match.stake
+            
+            creator_user.wins += 1
             creator_user.total_games += 1
             joiner_user.losses += 1
-            joiner_user.coins -= match.stake
             joiner_user.total_games += 1
             game_history.winner_id = creator_user.id
         else:
             match.stats.joiner_wins += 1
             players[match.joiner].record_win()
-            players[match.joiner].add_coins(match.stake)
             players[match.creator].record_loss()
-            players[match.creator].add_coins(-match.stake)
-            joiner_user.wins += 1
+            
+            # Update coins in one place and sync
             joiner_user.coins += match.stake
+            creator_user.coins -= match.stake
+            players[match.joiner].coins = joiner_user.coins
+            players[match.creator].coins = creator_user.coins
+            
+            # Update stats
+            players[match.joiner].stats.total_coins_won += match.stake
+            players[match.creator].stats.total_coins_lost += match.stake
+            
+            joiner_user.wins += 1
             joiner_user.total_games += 1
             creator_user.losses += 1
-            creator_user.coins -= match.stake
             creator_user.total_games += 1
             game_history.winner_id = joiner_user.id
             


### PR DESCRIPTION
This PR fixes the issue where incorrect amounts of coins were being deducted during matches.

Changes made:
1. Update coins in one place (database) and sync with in-memory state
2. Remove redundant coin updates from Player class
3. Fix double deduction bug
4. Properly track total coins won/lost

The issue was caused by updating coins in multiple places:
- Once in the in-memory Player object
- Once in the database User object

This led to double deductions in some cases. Now we:
1. Update coins only in the database User object
2. Sync the in-memory Player object with the database state
3. Update stats separately

Tested with various bet amounts to ensure correct deductions.